### PR TITLE
fix a bug in the sign up page

### DIFF
--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -29,7 +29,8 @@
                 android:id="@+id/username_edit_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:maxLines="1"/>
+                android:maxLines="1"
+                android:inputType="text"/>
 
         </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
Now, return is not allowed in the username field in sign up page.
On the phone, the keyboard will display "next", instead of "return".